### PR TITLE
Version 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ We're going to assume you have 2 E32 Modules attached to two Raspberry PIs. Thus
 ## Install the `e32` command line tool and get status
 
 ```
-wget http://lloydrochester.com/code/e32-1.2.tar.gz
-tar zxf e32-1.2.tar.gz
-cd e32-1.2
+wget http://lloydrochester.com/code/e32-1.3.tar.gz
+tar zxf e32-1.3.tar.gz
+cd e32-1.3
 ./configure
 make
 sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([e32], [1.2], [lloyd@lloydrochester.com])
+AC_INIT([e32], [1.3], [lloyd@lloydrochester.com])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AC_CONFIG_SRCDIR([config.h.in])
 AC_CONFIG_HEADERS([config.h])

--- a/src/e32.c
+++ b/src/e32.c
@@ -129,6 +129,7 @@ e32_init(struct E32 *dev, struct options *opts)
 {
   int ret;
 
+  dev->verbose = opts->verbose;
   dev->socket_list = NULL;
 
   ret = e32_init_gpio(opts, dev);
@@ -140,7 +141,6 @@ e32_init(struct E32 *dev, struct options *opts)
   if(ret == -1)
     return ret;
 
-  dev->verbose = opts->verbose;
   dev->prev_mode = -1;
 
   dev->socket_list = calloc(1, sizeof(struct List));
@@ -568,7 +568,7 @@ e32_cmd_read_version(struct E32 *dev)
 
   usleep(54000);
 
-  return bytes != 4;
+  return 0;
 }
 
 void

--- a/src/e32.c
+++ b/src/e32.c
@@ -255,7 +255,7 @@ e32_read_uart(struct E32* dev, uint8_t buf[], int n_bytes)
 
   do
   {
-    bytes = read(dev->uart_fd, buf, n_bytes);
+    bytes = read(dev->uart_fd, ptr, n_bytes);
     if(bytes == 0)
     {
       errno_output("timed out\n");
@@ -268,7 +268,7 @@ e32_read_uart(struct E32* dev, uint8_t buf[], int n_bytes)
     }
 
     total_bytes += bytes;
-    if(total_bytes < n_bytes)
+    if(total_bytes > n_bytes)
     {
       err_output("overrun expected %d bytes but read %d\n", n_bytes, total_bytes);
       return 3;

--- a/src/error.c
+++ b/src/error.c
@@ -85,7 +85,7 @@ err_output(const char *format, ...)
 static void
 output_errno(int err, const char *format, va_list ap)
 {
-  char buf[BUF_SIZE], userMsg[BUF_SIZE], errText[BUF_SIZE];
+  char buf[3*BUF_SIZE], userMsg[BUF_SIZE], errText[BUF_SIZE];
 
   vsnprintf(userMsg, BUF_SIZE, format, ap);
 
@@ -93,7 +93,7 @@ output_errno(int err, const char *format, va_list ap)
           (err > 0 && err <= MAX_ENAME) ?
           ename[err] : "?UNKNOWN?", strerror(err));
 
-  snprintf(buf, BUF_SIZE, "ERROR%s %s\n", errText, userMsg);
+  snprintf(buf, 3*BUF_SIZE-1, "ERROR%s %s\n", errText, userMsg);
 
   if(use_syslog)
   {

--- a/src/error.c
+++ b/src/error.c
@@ -93,10 +93,7 @@ output_errno(int err, const char *format, va_list ap)
           (err > 0 && err <= MAX_ENAME) ?
           ename[err] : "?UNKNOWN?", strerror(err));
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
   snprintf(buf, BUF_SIZE, "ERROR%s %s\n", errText, userMsg);
-#pragma GCC diagnostic pop
 
   if(use_syslog)
   {

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -23,12 +23,12 @@ gpio_permissions_valid()
     if(ret)
         errno_output("unable to GPIO on %s\n", GPIO_EXPORT_PATH);
 
+    // file has same uid as the user and has write privledges
+    if(uid == statbuf.st_uid && (statbuf.st_mode & S_IWUSR))
+      return 0;
+
     for(int i=0;i<ngroups;i++)
     {
-        // file has same uid as the user and has write privledges
-        if(uid == statbuf.st_uid && (statbuf.st_mode & S_IWUSR))
-            return 0;
-
         // user is in file's group and has write permissions
         if(groups[i] == statbuf.st_gid && (statbuf.st_mode & S_IWGRP))
             return 0;

--- a/src/main.c
+++ b/src/main.c
@@ -45,11 +45,6 @@ main(int argc, char *argv[])
     usage(argv[0]);
     return ret;
   }
-  else if(opts.help)
-  {
-    usage(argv[0]);
-    return EXIT_SUCCESS;
-  }
 
   ret = e32_init(&dev, &opts);
   if(ret)

--- a/src/options.c
+++ b/src/options.c
@@ -15,7 +15,7 @@ usage(char *progname)
 -t --test                  Perform a test\n\
 -v --verbose               Verbose Output\n\
 -s --status                Get status model, frequency, address, channel, data rate, baud, parity and transmit power.\n\
--y --tty                   The UART to use. Defaults to /dev/ttyAMA0\n\
+-y --tty                   The UART to use. Defaults to /dev/serial0 the soft link\n\
 -m --mode MODE             Set mode to normal, wake-up, power-save or sleep.\n\
    --m0                    GPIO M0 Pin for output\n\
    --m1                    GPIO M1 Pin for output\n\
@@ -46,7 +46,7 @@ options_init(struct options *opts)
   opts->input_file = NULL;
   opts->output_file = NULL;
   opts->fd_socket_unix = -1;
-  snprintf(opts->tty_name, 64, "/dev/ttyAMA0");
+  snprintf(opts->tty_name, 64, "/dev/serial0");
 }
 
 int


### PR DESCRIPTION
Improvements now support Raspberry Pi Zero
Slight Performance Improvement when checking GPIO Permissions
Code Cleanup
We default to /dev/serial0 for the uart instead of /dev/ttyAMA0 which is more portable across Raspberry Pi products