### PR TITLE
Write settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,9 +45,10 @@ m4/lt~obsolete.m4(LIBDL)
 Makefile
 src/Makefile
 *.o
-src/.deps
+.deps
 config.h
 tags
 e32
 \#*#
 \.\#*
+.vscode

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 AM_DISTCHECK_CONFIGURE_FLAGS = \
    --with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir)
 
-SUBDIRS = src systemd
+SUBDIRS = src systemd test
 dist_doc_DATA = README

--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ make
 
 ## Changing e32 settings
 
-We can use the `-w HEX` options to change settings. For example we could save the settings by doing a `e32 -w C000001A1744`. See the datasheet for each of these options. For the form XXYYYY1AZZ44. If XX=C0 parameters are saved to e32's EEPROM, if XX=C2 settings will be lost on power cycle. The address is represented by YYYY and the channel is represented by ZZ.
+We can use the `-w HEX` option to change settings. For example we could save the settings by doing a `e32 -w C000001A1744`. See the datasheet for each of these options. For the form XXYYYY1AZZ44. If XX=C0 parameters are saved to e32's EEPROM, if XX=C2 settings will be lost on power cycle. The address is represented by YYYY and the channel is represented by ZZ.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# EByte E32 SX1276 for the Raspberry Pi
+# EByte E32 SX1276 Software for the Raspberry Pi
 
 See this [Blog Post](https://lloydrochester.com/post/hardware/e32-sx1276-lora/) for details.
 
@@ -67,3 +67,7 @@ If you don't want the tarball you could build using the GNU Autotools.
 ./configure
 make
 ```
+
+## Changing e32 settings
+
+We can use the `-w HEX` options to change settings. For example we could save the settings by doing a `e32 -w C000001A1744`. See the datasheet for each of these options. For the form XXYYYY1AZZ44. If XX=C0 parameters are saved to e32's EEPROM, if XX=C2 settings will be lost on power cycle. The address is represented by YYYY and the channel is represented by ZZ.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ We're going to assume you have 2 E32 Modules attached to two Raspberry PIs. Thus
 ## Install the `e32` command line tool and get status
 
 ```
-wget http://lloydrochester.com/code/e32-1.6.tar.gz
-tar zxf e32-1.6.tar.gz
-cd e32-1.6
+wget http://lloydrochester.com/code/e32-1.7.tar.gz
+tar zxf e32-1.7.tar.gz
+cd e32-1.7
 ./configure
 make
 sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([e32], [1.6], [lloyd@lloydrochester.com])
+AC_INIT([e32], [1.7], [lloyd@lloydrochester.com])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 AC_CONFIG_SRCDIR([src/config.h.in])
@@ -48,5 +48,6 @@ AM_CONDITIONAL([HAVE_SYSTEMD], [test "x$with_systemdsystemunitdir" != "xno"])
 
 AC_CONFIG_FILES([Makefile
                  src/Makefile
-                 systemd/Makefile])
+                 systemd/Makefile
+                 test/Makefile])
 AC_OUTPUT

--- a/src/e32.c
+++ b/src/e32.c
@@ -304,7 +304,7 @@ e32_cmd_read_settings(struct E32 *dev)
     debug_output("reading settings\n");
 
   // set a .5 second timout
-  tty_set_read_with_timeout(dev->uart_fd, &dev->tty, 50);
+  tty_set_read_with_timeout(dev->uart_fd, &dev->tty, 5);
   err = e32_read_uart(dev, dev->settings, sizeof(dev->settings));
   if(err)
   {
@@ -530,7 +530,7 @@ e32_cmd_read_version(struct E32 *dev)
     debug_output("reading version\n");
 
   // set a .5 second timout
-  tty_set_read_with_timeout(dev->uart_fd, &dev->tty, 50);
+  tty_set_read_with_timeout(dev->uart_fd, &dev->tty, 5);
 
   err = e32_read_uart(dev, dev->version, sizeof(dev->version));
   if(err)

--- a/src/e32.c
+++ b/src/e32.c
@@ -631,8 +631,6 @@ e32_cmd_write_settings(struct E32 *dev, struct options *opts)
   if(bytes == -1)
    return -1;
 
-  usleep(80000);
-
   if(e32_cmd_read_settings(dev))
   {
     err_output("unable to read settings after setting them\n");

--- a/src/e32.h
+++ b/src/e32.h
@@ -13,10 +13,10 @@
 
 enum E32_mode
 {
-  normal,
-  wake_up,
-  power_save,
-  sleep_mode
+  NORMAL,
+  WAKE_UP,
+  POWER_SAVE,
+  SLEEP
 };
 
 enum E32_state
@@ -90,7 +90,7 @@ int
 e32_cmd_reset(struct E32 *dev);
 
 int
-e32_cmd_write_settings(struct E32 *dev);
+e32_cmd_write_settings(struct E32 *dev, struct options *opts);
 
 ssize_t
 e32_transmit(struct E32 *dev, uint8_t *buf, size_t buf_len);
@@ -99,6 +99,6 @@ int
 e32_receive(struct E32 *dev, uint8_t *buf, size_t buf_len);
 
 int
-e32_poll(struct E32 *dev, struct options* opts);
+e32_poll(struct E32 *dev, struct options *opts);
 
 #endif

--- a/src/e32.h
+++ b/src/e32.h
@@ -9,7 +9,20 @@
 #include "uart.h"
 #include "list.h"
 
-#define E32_TX_BUF_BYTES 512
+/*
+ The e32 has a TX buffer of 512 bytes but how the implemented it's usage
+ with the AUX pin makes things difficult. I've noticied if you write 512
+ bytes to it and then wait for AUX to go high, then write another 512 bytes
+ you will overwrite most of the 512 bytes. For example maybe the first 64
+ bytes would get transmitted then the next would be overwritten. However,
+ this seems to happen on the event the buffer is empty originally as if you
+ send 512 continuously the first 512 are dropped but the remaining would be
+ sent. This is a potential improvement but needs more consideration. The poor
+ documentation of the datasheet and how AUX is implemented makes figuring this
+ out quite difficult. For now we'll have to use 58 until a better solution
+ can be devised.
+*/
+#define E32_TX_BUF_BYTES 58
 
 enum E32_mode
 {

--- a/src/main.c
+++ b/src/main.c
@@ -70,38 +70,47 @@ main(int argc, char *argv[])
   }
   if(opts.reset)
   {
-    err |= e32_set_mode(&dev, 3);
+    err |= e32_set_mode(&dev, SLEEP);
     err |= e32_cmd_reset(&dev);
-    err |= e32_set_mode(&dev, 0);
+    err |= e32_set_mode(&dev, NORMAL);
     goto cleanup;
   }
-  if(opts.status)
+
+  /* must be in sleep mode to read or write settings */
+  if(opts.status || opts.settings_write_input[0])
   {
-    if(e32_set_mode(&dev, 3))
+    if(e32_set_mode(&dev, SLEEP))
     {
       err_output("unable to go to sleep mode\n");
       goto cleanup;
     }
-    if(e32_cmd_read_version(&dev))
-    {
-      err_output("unable to read version\n");
-      goto cleanup;
-    }
+  }
+
+  if(opts.status)
+  {
     if(e32_cmd_read_settings(&dev))
     {
       err_output("unable to read settings\n");
-      goto cleanup;
-    }
-    if(e32_set_mode(&dev, 0))
-    {
-      err_output("unable to go to normal mode\n");
       goto cleanup;
     }
     e32_print_version(&dev);
     e32_print_settings(&dev);
     goto cleanup;
   }
-  else if(opts.daemon)
+
+  if(opts.settings_write_input[0])
+  {
+    err |= e32_cmd_write_settings(&dev, &opts);
+  }
+
+  /* switch back to normal mode for tx/rx */
+  if(e32_set_mode(&dev, NORMAL))
+  {
+    err_output("unable to go to normal mode\n");
+    goto cleanup;
+  }
+
+  if(opts.daemon)
   {
     become_daemon();
     info_output("daemon started pid=%d", getpid());

--- a/src/main.c
+++ b/src/main.c
@@ -88,6 +88,11 @@ main(int argc, char *argv[])
 
   if(opts.status)
   {
+    if(e32_cmd_read_version(&dev))
+    {
+      err_output("unable to read version\n");
+      goto cleanup;
+    }
     if(e32_cmd_read_settings(&dev))
     {
       err_output("unable to read settings\n");

--- a/src/options.c
+++ b/src/options.c
@@ -17,6 +17,7 @@ usage(char *progname)
 -t --test                  Perform a test\n\
 -v --verbose               Verbose Output\n\
 -s --status                Get status model, frequency, address, channel, data rate, baud, parity and transmit power.\n\
+-w --write-settings        Write settings from hex. E.G. C000001A1744\n\
 -y --tty                   The UART to use. Defaults to /dev/serial0 the soft link\n\
 -m --mode MODE             Set mode to normal, wake-up, power-save or sleep.\n\
    --m0                    GPIO M0 Pin for output [%d]\n\
@@ -63,6 +64,7 @@ options_init(struct options *opts)
   opts->input_file = NULL;
   opts->output_file = NULL;
   opts->fd_socket_unix = -1;
+  memset(opts->settings_write_input, 0, sizeof(opts->settings_write_input));
   snprintf(opts->tty_name, 64, "/dev/serial0");
 }
 
@@ -79,6 +81,12 @@ options_print(struct options* opts)
   printf("option GPIO AUX Pin is %d\n", opts->gpio_aux);
   printf("option daemon %d\n", opts->daemon);
   printf("option TTY Name is %s\n", opts->tty_name);
+  if(opts->settings_write_input[0])
+  {
+    for(int i=0;i<6;i++)
+      printf("%x", opts->settings_write_input[i]);
+    puts("");
+  }
 }
 
 int
@@ -159,6 +167,50 @@ options_open_socket_unix(struct options *opts, char *optarg)
 }
 
 int
+options_parse_settings(struct options *opts, char *settings)
+{
+  int num_parsed, err;
+  char hexbyte[3];
+  uint8_t *ptr;
+
+  printf("parsing %s\n", settings);
+
+  if(strnlen(settings, 13) != 12)
+  {
+    fprintf(stderr, "options not of length 12");
+    err = 1;
+    goto bad_settings;
+  }
+
+  if(settings[0] != 'c' && settings[0] != 'C')
+  {
+    fprintf(stderr, "options don't start with 0xc\n");
+    err = 2;
+    goto bad_settings;
+  }
+
+  ptr = opts->settings_write_input;
+  hexbyte[2] = '\0';
+  for(int i=0; i<12; i=i+2)
+  {
+    hexbyte[0] = settings[i];
+    hexbyte[1] = settings[i+1];
+    num_parsed = sscanf(hexbyte, "%hhx", ptr++);
+    if(num_parsed != 1)
+    {
+      err_output("error parsing %s\n", hexbyte);
+      err = 3;
+      goto bad_settings;
+    }
+  }
+  return 0;
+
+bad_settings:
+  fprintf(stderr, "error parsing settings %s, expect form CXXXXXXXXXXX\n", settings);
+  return err;
+}
+
+int
 options_parse(struct options *opts, int argc, char *argv[])
 {
   int c;
@@ -182,6 +234,7 @@ options_parse(struct options *opts, int argc, char *argv[])
     {"status",                   no_argument, 0, 's'},
     {"tty",                required_argument, 0, 'y'},
     {"mode",               required_argument, 0, 'm'},
+    {"write-settings",     required_argument, 0, 'w'},
     {"m0",                 required_argument, 0,   0},
     {"m1",                 required_argument, 0,   0},
     {"aux",                required_argument, 0,   0},
@@ -196,7 +249,7 @@ options_parse(struct options *opts, int argc, char *argv[])
   while(1)
   {
     option_index = 0;
-    c = getopt_long(argc, argv, "hrtvsy:m:bdx:", long_options, &option_index);
+    c = getopt_long(argc, argv, "hrtvsy:m:bdx:w:", long_options, &option_index);
 
     if(c == -1)
       break;
@@ -216,6 +269,8 @@ options_parse(struct options *opts, int argc, char *argv[])
         strncpy(infile, optarg, BUF);
       else if(strcmp("tty", long_options[option_index].name) == 0)
         strncpy(opts->tty_name, optarg, 64);
+      else if(strcmp("write-input", long_options[option_index].name) == 0)
+        err |= options_parse_settings(opts, optarg);
       break;
     case 'h':
       opts->help = 1;
@@ -247,6 +302,9 @@ options_parse(struct options *opts, int argc, char *argv[])
       break;
     case 'd':
       opts->daemon = 1;
+      break;
+    case 'w':
+      err |= options_parse_settings(opts, optarg);
       break;
     }
   }

--- a/src/options.c
+++ b/src/options.c
@@ -86,6 +86,7 @@ options_print(struct options* opts)
   printf("option TTY Name is %s\n", opts->tty_name);
   if(opts->settings_write_input[0])
   {
+    printf("option write settings is: ");
     for(int i=0;i<6;i++)
       printf("%x", opts->settings_write_input[i]);
     puts("");

--- a/src/options.c
+++ b/src/options.c
@@ -17,7 +17,10 @@ usage(char *progname)
 -t --test                  Perform a test\n\
 -v --verbose               Verbose Output\n\
 -s --status                Get status model, frequency, address, channel, data rate, baud, parity and transmit power.\n\
--w --write-settings        Write settings from hex. E.G. C000001A1744\n\
+-w --write-settings HEX    Write settings from HEX. see datasheet for these 6 bytes. Example: -w C000001A1744.\n\
+                           For the form XXYYYY1AZZ44. If XX=C0 parameters are saved to e32's EEPROM, if XX=C2 settings\n\
+                           will be lost on power cycle. The address is represented by YYYY and the channel is represented\n\
+                           by ZZ.\n\
 -y --tty                   The UART to use. Defaults to /dev/serial0 the soft link\n\
 -m --mode MODE             Set mode to normal, wake-up, power-save or sleep.\n\
    --m0                    GPIO M0 Pin for output [%d]\n\

--- a/src/options.h
+++ b/src/options.h
@@ -1,10 +1,8 @@
 #ifndef OPTIONS_H
 #define OPTIONS_H
 #include "config.h"
-#include <arpa/inet.h>
 #include <getopt.h>
 #include <netinet/in.h>
-#include <netdb.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -14,7 +12,6 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
-#include <arpa/inet.h>
 #include "error.h"
 
 extern int use_syslog;

--- a/src/options.h
+++ b/src/options.h
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <arpa/inet.h>
 #include "error.h"
 
 extern int use_syslog;
@@ -33,6 +34,7 @@ struct options
   int input_standard;
   int output_standard;
   char tty_name[64];
+  uint8_t settings_write_input[6];
   FILE* input_file;
   FILE* output_file;
   struct sockaddr_in socket_udp_dest;
@@ -51,6 +53,9 @@ options_deinit(struct options *opts);
 
 int
 options_parse(struct options *opts, int argc, char *argv[]);
+
+int
+options_parse_settings(struct options *opts, char *settings);
 
 void
 options_print(struct options *opts);

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,0 +1,6 @@
+test_options_CFLAGS = -I$(top_srcdir)/src
+test_options_LDADD = ../src/options.o ../src/error.o
+
+check_PROGRAMS = test_options
+test_options_SOURCES = test_options.c $(top_builddir)/src/options.h $(top_builddir)/src/error.h
+TESTS = $(check_PROGRAMS)

--- a/test/test_options.c
+++ b/test/test_options.c
@@ -1,0 +1,85 @@
+#include "options.h"
+#include "error.h"
+
+struct options opts;
+
+void
+print_options()
+{
+    printf("options are: ");
+    for(int i=0;i<6;i++)
+        printf("%x", opts.settings_write_input[i]);
+    puts("");
+}
+
+int
+main(int argc, char *argv[])
+{
+    int err;
+    char settings[32];
+
+    // Test a good value
+    sprintf(settings, "%s", "C000001A17B4");
+
+    err = options_parse_settings(&opts, settings);
+
+    print_options();
+
+    if(opts.settings_write_input[0] != 0xC0)
+        return 1;
+    if(opts.settings_write_input[1] != 0x00)
+        return 2;
+    if(opts.settings_write_input[2] != 0x00)
+        return 3;
+    if(opts.settings_write_input[3] != 0x1A)
+        return 4;
+    if(opts.settings_write_input[4] != 0x17)
+        return 5;
+    if(opts.settings_write_input[5] != 0xB4)
+        return 6;
+
+    memset(opts.settings_write_input, 0, 6);
+    argc = 3;
+    argv[0] = strdup("test_options.c");
+    argv[1] = strdup("-w");
+    argv[2] = strdup("0000001A17B4");
+
+    // Test without leading C
+    sprintf(settings, "%s", "0000001A17B4");
+    err = options_parse_settings(&opts, settings);
+
+    if(err == 0)
+        return 7;
+    else
+        err = 0;
+
+    // Test invalid hex
+    sprintf(settings, "%s", "C00000ZA17B4");
+    err = options_parse_settings(&opts, settings);
+
+    if(err == 0)
+        return 8;
+    else
+        err = 0;
+
+    // Test too short
+    sprintf(settings, "%s", "C00000A17B4");
+    err = options_parse_settings(&opts, settings);
+
+    if(err == 0)
+        return 9;
+    else
+        err = 0;
+
+    // Test too long
+    sprintf(settings, "%s", "C00000A17B4AA");
+    err = options_parse_settings(&opts, settings);
+
+    if(err == 0)
+        return 10;
+    else
+        err = 0;
+
+
+    return err;
+}


### PR DESCRIPTION
This PR gives the ability to change the settings of the e32 with a command line option `-w`. These setting are things like air data rate, address, and channel (frequency). See README.md or the `-h` option.