### PR TITLE
v1.9.0 Asyncronous I/O

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ We're going to assume you have 2 E32 Modules attached to two Raspberry PIs. Thus
 ## Install the `e32` command line tool and get status
 
 ```
-wget http://lloydrochester.com/code/e32-1.8.0.tar.gz
-tar zxf e32-1.8.0.tar.gz
-cd e32-1.8.0
+wget http://lloydrochester.com/code/e32-1.9.0.tar.gz
+tar zxf e32-1.9.0.tar.gz
+cd e32-1.9.0
 ./configure
 make
 sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([e32], [1.8.0], [lloyd@lloydrochester.com])
+AC_INIT([e32], [1.9.0], [lloyd@lloydrochester.com])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 AC_CONFIG_SRCDIR([src/config.h.in])

--- a/scripts/e32rx
+++ b/scripts/e32rx
@@ -17,7 +17,7 @@ parser.add_argument('--datasock',
     default="/run/e32.data")
 parser.add_argument('--clientsock',
     help="client socket for e32 to send data this program",
-    default=str(Path.home())+"/client.sock")
+    default=str(Path.home())+"/e32.rx.data")
 
 args = parser.parse_args()
 

--- a/scripts/e32tx
+++ b/scripts/e32tx
@@ -45,7 +45,7 @@ msg = str.encode(args.message)
 print("sending", len(msg), msg)
 
 csock.sendto(msg, e32_sock)
-(msg, address) = csock.recvfrom(10)
+(msg, address) = csock.recvfrom(512)
 
 if len(msg) == 1 and msg[0] == 0:
     print("success! received 1 byte from socket", address)

--- a/scripts/e32tx
+++ b/scripts/e32tx
@@ -17,8 +17,11 @@ parser.add_argument('--datasock',
     help="data socket to send data to the e32",
     default="/run/e32.data")
 parser.add_argument('--clientsock',
-    help="client socket for e32 to send data this program",
-    default=str(Path.home())+"/client.sock")
+    help="socket e32 sends data to",
+    default=str(Path.home())+"/e32.tx.data")
+parser.add_argument('--skip-registration',
+    help="don't register this client for when data is received over LoRa",
+    action='store_true')
 
 args = parser.parse_args()
 
@@ -31,15 +34,16 @@ if os.path.exists(csock_file):
 csock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
 csock.bind(csock_file)
 
-print("registering socket", csock_file, "to", e32_sock)
-csock.sendto(b'', e32_sock)
-(msg, address) = csock.recvfrom(10)
+if not args.skip_registration:
+    print("registering socket", csock_file, "to", e32_sock)
+    csock.sendto(b'', e32_sock)
+    (msg, address) = csock.recvfrom(10)
 
-if len(msg) != 1 or msg[0] != 0:
-    print("unable to register client")
-    sys.exit(1)
-else:
-    print("client registered")
+    if len(msg) != 1 or msg[0] != 0:
+        print("unable to register client")
+        sys.exit(1)
+    else:
+        print("client registered")
 
 msg = str.encode(args.message)
 print("sending", len(msg), msg)

--- a/src/become_daemon.c
+++ b/src/become_daemon.c
@@ -1,8 +1,4 @@
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdlib.h>
-#include <stdio.h>
+
 #include "become_daemon.h"
 
 int // returns 0 on success non-zero on error
@@ -41,5 +37,21 @@ become_daemon()
   if(dup2(STDIN_FILENO, STDERR_FILENO) != STDERR_FILENO)
     return 6;
 
+  return 0;
+}
+
+int
+write_pidfile(char *file)
+{
+  pid_t pid;
+  FILE *fp;
+  fp = fopen(file, "w");
+  if(fp == NULL)
+  {
+    return 1;
+  }
+  pid = getpid();
+  fprintf(fp, "%d\n", pid);
+  fclose(fp);
   return 0;
 }

--- a/src/become_daemon.h
+++ b/src/become_daemon.h
@@ -1,7 +1,17 @@
 #ifndef BECOME_DAEMON_H
 #define BECOME_DAEMON_H
 
-// returns 0 on success -1 on error
-int become_daemon();
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int
+become_daemon();
+
+int
+write_pidfile(char *file);
 
 #endif

--- a/src/e32.h
+++ b/src/e32.h
@@ -23,7 +23,10 @@
  out quite difficult. For now we'll have to use 58 until a better solution
  can be devised.
 */
-#define E32_TX_BUF_BYTES 58
+#define E32_MAX_PACKET_LENGTH 58
+
+#define TX_BUF_BYTES 512
+#define RX_BUF_BYTES 512
 
 enum E32_mode
 {

--- a/src/main.c
+++ b/src/main.c
@@ -120,8 +120,17 @@ main(int argc, char *argv[])
 
   if(opts.daemon)
   {
-    become_daemon();
-    info_output("daemon started pid=%d", getpid());
+    err = become_daemon();
+    if(err)
+    {
+      err_output("mail: error becoming daemon: %d\n", err);
+      goto cleanup;
+    }
+    if(write_pidfile("/run/e32.pid"))
+    {
+      errno_output("unable to write pid file\n");
+    }
+    info_output("daemon started pid=%ld", getpid());
   }
 
   err |= e32_poll(&dev, &opts);

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,7 @@ void signal_handler(int sig)
   int exit_status;
 
   if(opts.daemon)
-    info_output("daemon stopping pid=%d", getpid());
+    info_output("daemon stopping pid=%d sig=%d", getpid(), sig);
 
   options_deinit(&opts);
   exit_status = e32_deinit(&dev, &opts);

--- a/src/uart.c
+++ b/src/uart.c
@@ -52,13 +52,23 @@ tty_open(char *pty_name, int *tty_fd, struct termios *tty)
 
   if(tcgetattr(*tty_fd, tty) == -1)
   {
-    err_output("unable to get tty attributes for %s\n", pty_name);
+    errno_output("tty_open: unable to get tty attributes for %s\n", pty_name);
     close(*tty_fd);
     return -1;
   }
 
-  cfsetispeed(tty, B9600);
-  cfsetospeed(tty, B9600);
+  if(cfsetispeed(tty, B9600) == -1)
+  {
+    errno_output("tty_open: unable to uart input speed\n");
+    return -1;
+  }
+
+  if(cfsetospeed(tty, B9600) == -1)
+  {
+    errno_output("tty_open: unable to set output speed\n");
+    return -1;
+  }
+
   cfmakeraw(tty);
 
   tty->c_cflag |= CREAD | CLOCAL;
@@ -69,8 +79,17 @@ tty_open(char *pty_name, int *tty_fd, struct termios *tty)
     return -1;
   }
 
-  tcflush(*tty_fd, TCIFLUSH);
-  tcdrain(*tty_fd);
+  if(tcflush(*tty_fd, TCIFLUSH) == -1)
+  {
+    errno_output("tty_open: unable to flush terminal\n");
+    return -1;
+  }
+
+  if(tcdrain(*tty_fd) == -1)
+  {
+    errno_output("tty_open: unable to drain terminal\n");
+    return -1;
+  }
 
   return 0;
 }

--- a/systemd/e32.service
+++ b/systemd/e32.service
@@ -3,9 +3,10 @@ Description=ebyte e32 systemd service
 
 [Service]
 Type=forking
+PIDFile=/run/e32.pid
 ExecStartPre=stat /dev/serial0
 ExecStartPre=/usr/local/bin/e32 --reset
-ExecStart=/usr/local/bin/e32 --daemon --sock-unix-data /run/e32.data --sock-unix-ctrl /run/e32.control
+ExecStart=/usr/local/bin/e32 -v --daemon --sock-unix-data /run/e32.data --sock-unix-ctrl /run/e32.control
 ExecStartPost=chown --reference=/dev/serial0 /run/e32.data /run/e32.control
 ExecStartPost=chmod --reference=/dev/serial0 /run/e32.data /run/e32.control
 StandardOutput=journal


### PR DESCRIPTION
This PR is to better handle sending and receiving of data, especially when close together in time. To have any sort of multi-sensor network this must be done cleanly. The state machine is changed such that we disable polling inputs when we are receiving. This wasn't done properly before. Obviously, we don't want to transmit in the middle of a reception. Some of the delays are removed to make the code faster. The python scripts are improved. A bug is fixed for the Raspberry Pi Zero where the service wouldn't start because systemd needed a file with the process ID inside. One other major change is we have separate buffers for sending and receiving data.