### PR TITLE
Fix status output for power and frequency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04 AS build
 
-ARG VERSION=1.10.0
+ARG VERSION=1.10.1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ We're going to assume you have 2 E32 Modules attached to two Raspberry PIs. Thus
 ## Install the `e32` command line tool and get status
 
 ```
-wget http://lloydrochester.com/code/e32-1.10.0.tar.gz
-tar zxf e32-1.10.0.tar.gz
-cd e32-1.10.0
+wget http://lloydrochester.com/code/e32-1.10.1.tar.gz
+tar zxf e32-1.10.1.tar.gz
+cd e32-1.10.1
 ./configure
 make
 sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([e32], [1.10.0], [lloyd@lloydrochester.com])
+AC_INIT([e32], [1.10.1], [lloyd@lloydrochester.com])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 
 AC_CONFIG_SRCDIR([src/config.h.in])

--- a/src/e32.c
+++ b/src/e32.c
@@ -433,23 +433,23 @@ e32_cmd_read_settings(struct E32 *dev)
   dev->fec = dev->settings[5] & 0b00000100;
   dev->fec >>= 2;
 
-  dev->tx_power_dbm = dev->settings[5] & 0b00000011;
-  switch(dev->tx_power_dbm)
+  dev->tx_power_attn_dbm = dev->settings[5] & 0b00000011;
+  switch(dev->tx_power_attn_dbm)
   {
     case 0:
-      dev->tx_power_dbm = 30;
+      dev->tx_power_attn_dbm = 0;
       break;
     case 1:
-      dev->tx_power_dbm = 27;
+      dev->tx_power_attn_dbm = -3;
       break;
     case 2:
-      dev->tx_power_dbm = 24;
+      dev->tx_power_attn_dbm = -6;
       break;
     case 3:
-      dev->tx_power_dbm = 21;
+      dev->tx_power_attn_dbm = -9;
       break;
     default:
-      dev->tx_power_dbm = 0;
+      dev->tx_power_attn_dbm = 0;
   }
 
   usleep(54000);
@@ -493,7 +493,7 @@ e32_print_settings(struct E32 *dev)
   info_output("UART Baud Rate:           %d bps\n", dev->uart_baud);
   info_output("Air Data Rate:            %d bps\n", dev->air_data_rate);
   info_output("Channel:                  %d\n", dev->channel);
-  info_output("Frequency                 %d MHz\n", dev->channel+410);
+  info_output("Frequency                 %d MHz\n", dev->channel+dev->frequency_min_mhz);
 
   if(dev->transmission_mode)
     info_output("Transmission Mode:        Transparent\n");
@@ -512,7 +512,7 @@ e32_print_settings(struct E32 *dev)
   else
     info_output("Forward Error Correction: off\n");
 
-  info_output("TX Power:                 %d dBm\n", dev->tx_power_dbm);
+  info_output("TX Power Attenuation:     %d dBm\n", dev->tx_power_attn_dbm);
 }
 
 int
@@ -557,21 +557,33 @@ e32_cmd_read_version(struct E32 *dev)
   {
     case 0x32:
       dev->frequency_mhz = 433;
+      dev->frequency_min_mhz = 410;
+      dev->frequency_max_mhz = 441;
       break;
     case 0x38:
       dev->frequency_mhz = 470;
+      dev->frequency_min_mhz = 410;
+      dev->frequency_max_mhz = 525;
       break;
     case 0x45:
       dev->frequency_mhz = 868;
+      dev->frequency_min_mhz = 862;
+      dev->frequency_max_mhz = 893;
       break;
     case 0x44:
       dev->frequency_mhz = 915;
+      dev->frequency_min_mhz = 900;
+      dev->frequency_max_mhz = 931;
       break;
     case 0x46:
       dev->frequency_mhz = 170;
+      dev->frequency_min_mhz = 160;
+      dev->frequency_max_mhz = 173;
       break;
     default:
       dev->frequency_mhz = 0;
+      dev->frequency_min_mhz = 0;
+      dev->frequency_max_mhz = 0;
   }
 
   dev->ver = dev->version[2];
@@ -589,7 +601,9 @@ e32_print_version(struct E32 *dev)
   for(int i=0;i<4;i++)
     info_output("%02x", dev->version[i]);
   info_output("\n");
-  info_output("Frequency:                %d MHz\n", dev->frequency_mhz);
+  info_output("Frequency Typ:            %d MHz\n", dev->frequency_mhz);
+  info_output("Frequency Min:            %d MHz\n", dev->frequency_min_mhz);
+  info_output("Frequency Max:            %d MHz\n", dev->frequency_max_mhz);
   info_output("Version:                  %d\n", dev->ver);
   info_output("Features:                 0x%02x\n", dev->features);
 }

--- a/src/e32.h
+++ b/src/e32.h
@@ -58,6 +58,8 @@ struct E32
   uint8_t version[4];
   uint8_t settings[6];
   int frequency_mhz;
+  int frequency_min_mhz;
+  int frequency_max_mhz;
   int ver;
   int features;
   int power_down_save;
@@ -72,7 +74,7 @@ struct E32
   int io_drive;
   int wireless_wakeup_time;
   int fec;
-  int tx_power_dbm;
+  int tx_power_attn_dbm;
   struct List *socket_list;
 };
 


### PR DESCRIPTION
Per [Issue 27](https://github.com/lloydroc/ebyte-sx1276/issues/27) this will fix output of the status command `e32 -s` to have correct frequency output and change the power. There is no way I've found from the datasheet to know what the max power is from the status and version command output on the board. Thus, we output the attenuation in dBm.

Here is what the output looks like now:
```
$ e32 -s
Version Raw Value:        0xc3450d14
Frequency Typ:            868 MHz
Frequency Min:            862 MHz
Frequency Max:            893 MHz
Version:                  13
Features:                 0x14
Settings Raw Value:       0xc000011a1744
Power Down Save:          Save parameters on power down
Address:                  0x0001
Parity:                   8N1
UART Baud Rate:           9600 bps
Air Data Rate:            2400 bps
Channel:                  23
Frequency                 885 MHz
Transmission Mode:        Fixed
IO Drive:                 TXD and AUX push-pull output, RXD pull-up input
Wireless Wakeup Time:     250 ms
Forward Error Correction: on
TX Power Attenuation:     0 dBm
```